### PR TITLE
Fix Bing construction in donwloader.py

### DIFF
--- a/bing_image_downloader/downloader.py
+++ b/bing_image_downloader/downloader.py
@@ -9,7 +9,7 @@ except ImportError:  # Python 3
 
 
 def download(query, limit=100, output_dir='dataset', adult_filter_off=True, 
-force_replace=False, timeout=60, verbose=True):
+force_replace=False, timeout=60, filters='', verbose=True):
 
     # engine = 'bing'
     if adult_filter_off:
@@ -34,7 +34,7 @@ force_replace=False, timeout=60, verbose=True):
         sys.exit(1)
         
     print("[%] Downloading Images to {}".format(str(image_dir.absolute())))
-    bing = Bing(query, limit, image_dir, adult, timeout, verbose)
+    bing = Bing(query, limit, image_dir, adult, timeout, filters, verbose)
     bing.run()
 
 


### PR DESCRIPTION
The constructor arguments are passed as positional
arguments, however the filter was missing.
The consequence was that the filter in Bing had
a wrong value ('True' by default).