### PR TITLE
Error protection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This package uses async url, which makes it very fast while downloading.<br/>
 ### Disclaimer<br />
 
 This program lets you download tons of images from Bing.
-Please do not download or use any image that violates its copyright terms. 
+Please do not download or use any image that violates its copyright terms.
 
 ### Installation <br />
 ```sh
 pip install bing-image-downloader
 ```
 
-or 
+or
 ```bash
 git clone https://github.com/gurugaurav/bing_image_downloader
 cd bing_image_downloader
@@ -30,7 +30,7 @@ pip install .
 ### Usage <br />
 ```python
 from bing_image_downloader import downloader
-downloader.download(query_string, limit=100,  output_dir='dataset', adult_filter_off=True, force_replace=False, timeout=60, verbose=True)
+downloader.download(query_string, limit=100,  output_dir='dataset', adult_filter_off=True, force_replace=False, timeout=60, verbose=True, error_protection=False)
 ```
 
 `query_string` : String to be searched.<br />
@@ -41,6 +41,7 @@ downloader.download(query_string, limit=100,  output_dir='dataset', adult_filter
 `timeout` : (optional, default is 60) timeout for connection in seconds.<br />
 `filter` : (optional, default is "") filter, choose from [line, photo, clipart, gif, transparent]<br />
 `verbose` : (optional, default is True) Enable downloaded message.<br />
+`error_protection` : (optional, default is False) Enable protections from url errors, like disconnects.<br />
 
 
 You can also test the programm by runnning `test.py keyword`
@@ -58,7 +59,3 @@ https://pypi.org/project/bing-image-downloader/
 You can buy me a coffee if this project was helpful to you.</br>
 
 [<img src="https://www.buymeacoffee.com/assets/img/guidelines/download-assets-sm-1.svg" alt="Show your support" width="180"/>](https://www.buymeacoffee.com/gurugaurav)
-  
-
-
-

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ downloader.download(query_string, limit=100,  output_dir='dataset', adult_filter
 `error_protection` : (optional, default is False) Enable protections from url errors, like disconnects.<br />
 
 
-You can also test the programm by runnning `test.py keyword`
+You can also test the program by runnning `test.py keyword`
 
 
 ### PyPi <br />

--- a/bing_image_downloader/bing.py
+++ b/bing_image_downloader/bing.py
@@ -4,6 +4,7 @@ import urllib
 import imghdr
 import posixpath
 import re
+from time import sleep
 
 '''
 Python api to download image form Bing.
@@ -12,7 +13,7 @@ Author: Guru Prasad (g.gaurav541@gmail.com)
 
 
 class Bing:
-    def __init__(self, query, limit, output_dir, adult, timeout,  filter='', verbose=True):
+    def __init__(self, query, limit, output_dir, adult, timeout,  filter='', verbose=True, error_protection=False):
         self.download_count = 0
         self.query = query
         self.output_dir = output_dir
@@ -20,6 +21,7 @@ class Bing:
         self.filter = filter
         self.verbose = verbose
         self.seen = set()
+        self.error_protection = error_protection
 
         assert type(limit) == int, "limit must be integer"
         self.limit = limit
@@ -28,7 +30,7 @@ class Bing:
 
         # self.headers = {'User-Agent': 'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0'}
         self.page_counter = 0
-        self.headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) ' 
+        self.headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) '
       'AppleWebKit/537.11 (KHTML, like Gecko) '
       'Chrome/23.0.1271.64 Safari/537.11',
       'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -62,7 +64,7 @@ class Bing:
         with open(str(file_path), 'wb') as f:
             f.write(image)
 
-    
+
     def download_image(self, link):
         self.download_count += 1
         # Get the image link
@@ -72,21 +74,50 @@ class Bing:
             file_type = filename.split(".")[-1]
             if file_type.lower() not in ["jpe", "jpeg", "jfif", "exif", "tiff", "gif", "bmp", "png", "webp", "jpg"]:
                 file_type = "jpg"
-                
+            downloaded = False
             if self.verbose:
                 # Download the image
                 print("[%] Downloading Image #{} from {}".format(self.download_count, link))
-                
-            self.save_image(link, self.output_dir.joinpath("Image_{}.{}".format(
-                str(self.download_count), file_type)))
-            if self.verbose:
+            delay = 1
+            while self.error_protection:
+                try:
+                    self.save_image(link, self.output_dir.joinpath("Image_{}.{}".format(
+                        str(self.download_count), file_type)))
+                    downloaded = True
+                    break
+                except urllib.error.URLError:
+                    if self.verbose:
+                        print("[%] URLError, sleeping for " + str(delay))
+
+                    # sleeping for 1 second at a time makes it easier to escape out
+                    for i in range(delay):
+                        sleep(1)
+                    delay *= 2
+                    if self.doub_sum(delay) > self.timeout : break
+
+            else:
+                self.save_image(link, self.output_dir.joinpath("Image_{}.{}".format(
+                    str(self.download_count), file_type)))
+                downloaded = True
+            if self.verbose and downloaded:
                 print("[%] File Downloaded !\n")
+            elif self.verbose:
+                print("[%] Timeout exceeded : Persistent Connection Error, File not Downloaded !\n")
+
 
         except Exception as e:
             self.download_count -= 1
             print("[!] Issue getting: {}\n[!] Error:: {}".format(link, e))
 
-    
+    # for calculating the error_protection delay
+    def doub_sum(self, val):
+        sum = 0
+        val = int(val)
+        while val > 0:
+            sum += val
+            val //= 2
+        return sum
+
     def run(self):
         while self.download_count < self.limit:
             if self.verbose:
@@ -96,7 +127,27 @@ class Bing:
                           + '&first=' + str(self.page_counter) + '&count=' + str(self.limit) \
                           + '&adlt=' + self.adult + '&qft=' + ('' if self.filter is None else self.get_filter(self.filter))
             request = urllib.request.Request(request_url, None, headers=self.headers)
-            response = urllib.request.urlopen(request)
+
+            delay = 1
+            while self.error_protection:
+                try:
+                    response = urllib.request.urlopen(request)
+                    break
+                except urllib.error.URLError:
+                    if self.verbose:
+                        print("URLError on page, sleeping for " + str(delay))
+
+                    # sleeping for 1 second at a time makes it easier to escape out
+                    for i in range(delay):
+                        sleep(1.0)
+                    delay *= 2
+                    if self.verbose:
+                        print('\n\n[!!]Retrying page: {}\n'.format(self.page_counter + 1))
+                    if self.doub_sum(delay) > self.timeout :
+                        break
+            else:
+                response = urllib.request.urlopen(request)
+
             html = response.read().decode('utf8')
             if html ==  "":
                 print("[%] No more images are available")

--- a/bing_image_downloader/bing.py
+++ b/bing_image_downloader/bing.py
@@ -135,7 +135,7 @@ class Bing:
                     break
                 except urllib.error.URLError:
                     if self.verbose:
-                        print("URLError on page, sleeping for " + str(delay))
+                        print("[%] URLError on page, sleeping for " + str(delay))
 
                     # sleeping for 1 second at a time makes it easier to escape out
                     for i in range(delay):

--- a/bing_image_downloader/downloader.py
+++ b/bing_image_downloader/downloader.py
@@ -8,8 +8,8 @@ except ImportError:  # Python 3
     from .bing import Bing
 
 
-def download(query, limit=100, output_dir='dataset', adult_filter_off=True, 
-force_replace=False, timeout=60, filter="", verbose=True):
+def download(query, limit=100, output_dir='dataset', adult_filter_off=True,
+force_replace=False, timeout=60, filter="", verbose=True, error_protection=False):
 
     # engine = 'bing'
     if adult_filter_off:
@@ -17,7 +17,7 @@ force_replace=False, timeout=60, filter="", verbose=True):
     else:
         adult = 'on'
 
-    
+
     image_dir = Path(output_dir).joinpath(query).absolute()
 
     if force_replace:
@@ -32,9 +32,9 @@ force_replace=False, timeout=60, filter="", verbose=True):
     except Exception as e:
         print('[Error]Failed to create directory.', e)
         sys.exit(1)
-        
+
     print("[%] Downloading Images to {}".format(str(image_dir.absolute())))
-    bing = Bing(query, limit, image_dir, adult, timeout, filter, verbose)
+    bing = Bing(query, limit, image_dir, adult, timeout, filter, verbose, error_protection)
     bing.run()
 
 

--- a/test.py
+++ b/test.py
@@ -7,16 +7,15 @@ if len(sys.argv) == 3:
     filter=sys.argv[2]
 else:
     filter=""
-    
-            
+
 downloader.download(
     query,
     limit=10,
     output_dir="dataset",
     adult_filter_off=True,
     force_replace=False,
-    timeout=60,
+    timeout=4,
     filter=filter,
     verbose=True,
+    error_protection=True
 )
-


### PR DESCRIPTION
I added an additional argument, giving functionality to an "error protection mode".
The advantage of this mode is that it makes the program much more robust in its error handling. [Url Errors](https://docs.python.org/3/library/urllib.error.html) could cause problems or occasional make the program crash. These errors are from things like disconnects, such as when Bing refuses your request. These sort of errors are often random, and will occur server-side.

When you're trying to download a very large number of images, such as for machine learning projects, that can cause some obvious issues. Thus, I made the error protection mode wait for an appropriate amount of time and retry, while ensuring the total retry wait time doesn't wait longer than the timeout variable.

I've been testing it out, and this solution works pretty well!
