### PR TITLE
Add page limit option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ dataset
 dist
 image_search.egg-info
 **/.vscode/*
+
+### macOS ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+### Jetbrains ###
+.idea/**

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ pip install .
 ### Usage <br />
 ```python
 from bing_image_downloader import downloader
-downloader.download(query_string, limit=100,  output_dir='dataset', adult_filter_off=True, force_replace=False, timeout=60, verbose=True)
+downloader.download(query_string, limit=100,  output_dir='dataset', page_limit=100, adult_filter_off=True, force_replace=False, timeout=60, verbose=True)
 ```
 
 `query_string` : String to be searched.<br />
 `limit` : (optional, default is 100) Number of images to download.<br />
 `output_dir` : (optional, default is 'dataset') Name of output dir.<br />
+`page_limit` : (optional, default is 100) Number of pages to scan for images.<br />
 `adult_filter_off` : (optional, default is True) Enable of disable adult filteration.<br />
 `force_replace` : (optional, default is False) Delete folder if present and start a fresh download.<br />
 `timeout` : (optional, default is 60) timeout for connection in seconds.<br />

--- a/bing_image_downloader/bing.py
+++ b/bing_image_downloader/bing.py
@@ -12,7 +12,7 @@ Author: Guru Prasad (g.gaurav541@gmail.com)
 
 
 class Bing:
-    def __init__(self, query, limit, output_dir, adult, timeout,  filter='', verbose=True):
+    def __init__(self, query, limit, output_dir, page_limit, adult, timeout,  filter='', verbose=True):
         self.download_count = 0
         self.query = query
         self.output_dir = output_dir
@@ -23,6 +23,8 @@ class Bing:
 
         assert type(limit) == int, "limit must be integer"
         self.limit = limit
+        assert type(page_limit) == int, "page_limit must be integer"
+        self.page_limit = page_limit
         assert type(timeout) == int, "timeout must be integer"
         self.timeout = timeout
 
@@ -88,7 +90,7 @@ class Bing:
 
     
     def run(self):
-        while self.download_count < self.limit:
+        while self.download_count < self.limit and self.page_counter < self.page_limit:
             if self.verbose:
                 print('\n\n[!!]Indexing page: {}\n'.format(self.page_counter + 1))
             # Parse the page source and download pics
@@ -112,4 +114,11 @@ class Bing:
                     self.download_image(link)
 
             self.page_counter += 1
+
+        if self.download_count >= self.limit:
+            print("[!!]Reached download limit")
+
+        if self.page_counter >= self.page_limit:
+            print("[!!]Reached page limit")
+
         print("\n\n[%] Done. Downloaded {} images.".format(self.download_count))

--- a/bing_image_downloader/downloader.py
+++ b/bing_image_downloader/downloader.py
@@ -8,16 +8,14 @@ except ImportError:  # Python 3
     from .bing import Bing
 
 
-def download(query, limit=100, output_dir='dataset', adult_filter_off=True, 
-force_replace=False, timeout=60, filter="", verbose=True):
-
+def download(query, limit=100, output_dir='dataset', page_limit=100, adult_filter_off=True,
+             force_replace=False, timeout=60, filter="", verbose=True):
     # engine = 'bing'
     if adult_filter_off:
         adult = 'off'
     else:
         adult = 'on'
 
-    
     image_dir = Path(output_dir).joinpath(query).absolute()
 
     if force_replace:
@@ -32,9 +30,9 @@ force_replace=False, timeout=60, filter="", verbose=True):
     except Exception as e:
         print('[Error]Failed to create directory.', e)
         sys.exit(1)
-        
+
     print("[%] Downloading Images to {}".format(str(image_dir.absolute())))
-    bing = Bing(query, limit, image_dir, adult, timeout, filter, verbose)
+    bing = Bing(query, limit, image_dir, page_limit, adult, timeout, filter, verbose)
     bing.run()
 
 


### PR DESCRIPTION
I've noticed when downloading over 30 images or so, sometimes it just can't find more, and it keeps indexing the pages without any success. To counter this, I added a `page_limit` option that limits the number of pages it indexes. I changed the **README** as well to include this option, and I also added some prints to show whether it stopped because of the download limit or the page limit.