### PR TITLE
Fix for Error:: URL can't contain control characters ' '

### DIFF
--- a/bing_image_downloader/bing.py
+++ b/bing_image_downloader/bing.py
@@ -138,6 +138,7 @@ class Bing:
                 print("[%] No more images are available")
                 break
             links = re.findall('murl&quot;:&quot;(.*?)&quot;', html)
+            links = [link.replace(" ", "%20") for link in links]
             if self.verbose:
                 print("[%] Indexed {} Images on Page {}.".format(len(links), self.page_counter + 1))
                 print("\n===============================================\n")


### PR DESCRIPTION
I encountered control character errors with the download() function due to URLs containing blank spaces. The fix replaces " " with "%20"

Related to this issue:
https://github.com/gurugaurav/bing_image_downloader/issues/30